### PR TITLE
vaapi: add option to select a non-default device path

### DIFF
--- a/options/options.c
+++ b/options/options.c
@@ -89,6 +89,7 @@ extern const struct m_sub_options angle_conf;
 extern const struct m_sub_options cocoa_conf;
 extern const struct m_sub_options macos_conf;
 extern const struct m_sub_options android_conf;
+extern const struct m_sub_options vaapi_conf;
 
 static const struct m_sub_options screenshot_conf = {
     .opts = image_writer_opts,
@@ -754,6 +755,10 @@ const m_option_t mp_opts[] = {
 #if HAVE_CUDA_HWACCEL
     OPT_CHOICE_OR_INT("cuda-decode-device", cuda_device, 0,
                       0, INT_MAX, ({"auto", -1})),
+#endif
+
+#if HAVE_VAAPI
+    OPT_SUBSTRUCT("vaapi", vaapi_opts, vaapi_conf, 0),
 #endif
 
 #if HAVE_ENCODING

--- a/options/options.h
+++ b/options/options.h
@@ -347,6 +347,7 @@ typedef struct MPOpts {
     struct macos_opts *macos_opts;
     struct android_opts *android_opts;
     struct dvd_opts *dvd_opts;
+    struct vaapi_opts *vaapi_opts;
 
     int cuda_device;
 } MPOpts;


### PR DESCRIPTION
On machines with multiple GPUs, /dev/dri/renderD128 isn't guaranteed
to point to a valid vaapi device. This just adds the option to specify
what path to use.

The old fallback /dev/dri/card0 is gone but that's not a loss as its
a legacy interface no longer accepted as valid by libva.

Fixes #4320

Ideally, you shouldn't need enter any text here, and your commit messages should
explain your changes sufficiently (especially why they are needed). Read
https://github.com/mpv-player/mpv/blob/master/DOCS/contribute.md for coding
style and development conventions. Remove this text block, but if you haven't
agreed to it before, leave the following sentence in place:

I agree that my changes can be relicensed to LGPL 2.1 or later.
